### PR TITLE
missing didUpdateWidget() #60

### DIFF
--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -48,6 +48,14 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
     );
   }
 
+  @override
+  void didUpdateWidget(oldWidget)
+  {
+    controllerSubscription?.cancel();
+    controllerSubscription =
+        widget.controller?.events.listen(_controllerListener);
+  }
+
   void onSwipeDirectionChanged(CardSwiperDirection direction) {
     switch (direction) {
       case CardSwiperDirection.none:


### PR DESCRIPTION
## Description

Under some circumstances, like explained in [State/initState](https://api.flutter.dev/flutter/widgets/State/initState.html), the event subscription must be resubscribed in an overridden `didUpdateWidget()`.

## Related Issues

- Closes #60
